### PR TITLE
Fix esm import and logging + 

### DIFF
--- a/discotope3/esm/inverse_folding/multichain_util.py
+++ b/discotope3/esm/inverse_folding/multichain_util.py
@@ -7,9 +7,6 @@ from typing import List, Sequence, Tuple
 import biotite.structure
 import numpy as np
 import torch
-#from esm.inverse_folding.util import (extract_coords_from_structure,
-#                                      get_encoder_output, get_sequence_loss,
-#                                      load_coords, load_structure)
 from .util import (
     extract_coords_from_structure,
     get_encoder_output,

--- a/discotope3/esm/pretrained.py
+++ b/discotope3/esm/pretrained.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import torch
 
-import discotope3.esm
+import discotope3.esm as esm
 
 
 def _has_regression_weights(model_name):
@@ -96,7 +96,6 @@ def has_emb_layer_norm_before(model_state):
 
 
 def _load_model_and_alphabet_core_v1(model_data):
-    import esm  # since esm.inverse_folding is imported below, you actually have to re-import esm here
 
     alphabet = esm.Alphabet.from_architecture(model_data["args"].arch)
 

--- a/discotope3/main.py
+++ b/discotope3/main.py
@@ -14,7 +14,6 @@ from discotope3 import make_dataset
 
 ROOT_PATH = Path(os.path.dirname(__file__)).parent
 sys.path.insert(0, ROOT_PATH)
-import make_dataset
 import warnings
 
 # Ignore Biopython deprecation warnings

--- a/discotope3/main.py
+++ b/discotope3/main.py
@@ -14,7 +14,7 @@ from discotope3 import make_dataset
 
 ROOT_PATH = Path(os.path.dirname(__file__)).parent
 sys.path.insert(0, ROOT_PATH)
-
+import make_dataset
 import warnings
 
 # Ignore Biopython deprecation warnings
@@ -44,6 +44,9 @@ import xgboost as xgb
 from Bio.PDB import PDBIO, Select
 from Bio.PDB.PDBParser import PDBParser
 from discotope3.make_dataset import Discotope_Dataset_web
+
+
+
 
 def cmdline_args():
     # Make parser object

--- a/discotope3/main.py
+++ b/discotope3/main.py
@@ -43,8 +43,7 @@ import requests
 import xgboost as xgb
 from Bio.PDB import PDBIO, Select
 from Bio.PDB.PDBParser import PDBParser
-from .make_dataset import Discotope_Dataset_web
-
+from discotope3.make_dataset import Discotope_Dataset_web
 
 def cmdline_args():
     # Make parser object

--- a/discotope3/make_dataset.py
+++ b/discotope3/make_dataset.py
@@ -523,22 +523,13 @@ def renumber_res_ids(array, start=None):
     array.res_id = new_res_ids
     return array
 
+
 def get_atomarray_bfacs(atom_array: biotite.structure.AtomArray) -> np.array:
     """
-    Return per-residue B-factors (AF2 confidence) from biotite.structure.AtomArray
+    Return one B-factor/pLDDT value per residue from biotite.structure.AtomArray
     """
-
-    # Get relative indices starting from 1. Copy to avoid modifying original
-    atom_array_renum = renumber_res_ids(
-        copy.deepcopy(atom_array), start=1
-    )
-
-    # Extract B-factors, map to residues
-    res_idxs_dict = {r: i for i, r in enumerate(atom_array_renum.res_id)}
-    res_idxs_uniq = np.array(list(res_idxs_dict.values()))
-    res_bfacs = atom_array_renum.b_factor[res_idxs_uniq]
-
-    return res_bfacs
+    starts = biotite.structure.residues.get_residue_starts(atom_array)
+    return atom_array.b_factor[starts]
 
 
 def structure_extract_seq_residx_chain_bfac_rsas_diam(struc_full, chain_id):


### PR DESCRIPTION
Fixes two issues:
1)
Works both  :
- python discotope3/main.py  (as described in .README)
- python -m discotope3.main  (nice if you want to run it from package install). 

2) AlphaFold preprocessing bug  
`get_atomarray_bfacs()` could return too few residues due to consecutive duplicate `res_id` values, causing shape mismatches. 

Fix is to use Biotite numbering (`get_residue_starts`) to guarantee one value per residue.
